### PR TITLE
improved time visibility and wrapped mobile menu

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -129,6 +129,25 @@ ol {
     background-color: white;
 }
 
+.navbar-menu.is-active{
+    display: flex;
+    flex-wrap: wrap;
+}
+
+.navbar-burger{
+    border-radius: 4px;
+    background-color: #e1f4f3;
+    height: 2.25rem;
+    width: 2.25rem;
+}
+
+.navbar-burger:hover{
+    border-radius: 4px;
+    background-color: #c3dfde;
+    height: 2.25rem;
+    width: 2.25rem;
+}
+
 .navbar-burger.is-active{
     background-color: white;
 }
@@ -287,6 +306,7 @@ body {
 /* end animation styles */
 
 .time-box {
+    -webkit-text-stroke: 1px #e1f4f3;
     font-size: 24px;
     /* padding: .25rem; */
     color: #333333;


### PR DESCRIPTION
Just changed a few styling things for the site. Added an outline to the time so you can see it better on dark backgrounds. I also made a background for the burger menu for the same reason. Inside the mobile menu I wrapped the display so the icons list horizontally instead of vertically. I think it is an improvement but if you guys don't like how it looks it is super easy to switch back